### PR TITLE
Fixing dependency

### DIFF
--- a/framework/pom.xml
+++ b/framework/pom.xml
@@ -30,7 +30,7 @@
 		<dependency>
 			<groupId>org.uncommons.maths</groupId>
 			<artifactId>uncommons-maths</artifactId>
-			<version>1.2.2</version>
+			<version>1.2.2a</version>
 		</dependency>
 		<dependency>
 			<groupId>com.google.collections</groupId>


### PR DESCRIPTION
The uncommon.maths dependency was not working before due to outdated jFree 1.0.8 dependency.