### PR TITLE
Update RingMigration.java

### DIFF
--- a/framework/src/java/main/org/uncommons/watchmaker/framework/islands/RingMigration.java
+++ b/framework/src/java/main/org/uncommons/watchmaker/framework/islands/RingMigration.java
@@ -55,7 +55,7 @@ public class RingMigration implements Migration<Object>
                 // Select the migrants that will move to the next island to make room for the immigrants here.
                 // Randomise the population so that there is no bias concerning which individuals are migrated.
                 Collections.shuffle(island, rng);
-                migrants = new ArrayList<EvaluatedCandidate<S>>(island.subList(island.size() - migrantCount, island.size()));
+                migrants = new ArrayList<EvaluatedCandidate<S>>(island.subList(Math.max(0,island.size() - migrantCount), island.size()));
             }
             // Copy the immigrants over the last members of the population (those that are themselves
             // migrating to the next island).


### PR DESCRIPTION
Watchmaker crushes when island size is smaller then migrantCount. And it's not dependent just on the populationSize entered by user but on algorithms itself so it might be more logical not to crush